### PR TITLE
Fix gradlew JVM options quoting

### DIFF
--- a/android/gradlew
+++ b/android/gradlew
@@ -44,7 +44,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS="-Xmx64m -Xms64m"
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"


### PR DESCRIPTION
## Summary
- fix quoting of JVM options in `android/gradlew`

## Testing
- `npm run check` *(fails: Argument of type ... is not assignable ...)*

------
https://chatgpt.com/codex/tasks/task_e_6856d9174bfc8325a6e6369e79a4e5a2